### PR TITLE
useDailyCorona 커스텀 훅의 warning 을 수정합니다

### DIFF
--- a/src/hooks/useDailyCorona.tsx
+++ b/src/hooks/useDailyCorona.tsx
@@ -1,10 +1,11 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useState, useRef} from 'react';
 import coronaApiProps from '../interfaces/coronaApiProps.interface';
 import axios from "axios";
 import moment from "moment";
 import {DAILY_CORONA_STATUS_API_SERVICE_KEY} from "../constants";
 
 export default function useDailyCorona(): coronaApiProps[] | undefined {
+  const isCancelled = useRef(false);
   const [items, setItems] = useState<coronaApiProps[]>();
 
   const params = setParams();
@@ -15,18 +16,17 @@ export default function useDailyCorona(): coronaApiProps[] | undefined {
         params,
       })
       .then(response => {
-        setItems(JSON.parse(JSON.stringify(response.data)).response.body.items.item);
+        if (!isCancelled.current) {
+          setItems(JSON.parse(JSON.stringify(response.data)).response.body.items.item);
+        }
       });
   }
 
   useEffect(() => {
-    let isLoading = true;
-    if (isLoading) {
-      setCorona();
-    }
+    setCorona();
     return () => {
-      isLoading = false;
-    }
+      isCancelled.current = true;
+    };
   }, []);
 
   return items;


### PR DESCRIPTION
## 배경
Province 컴포넌트를 테스트 할 때 warning 이 나타납니다.

## 확인 방법
docker 로 node container 를 실행 후 `docker exec -it node npm test` 를 실행합니다.

## 작업내용
[에러노트](https://www.notion.so/monssosa/Can-t-perform-a-React-state-update-on-an-unmounted-component-c5bcdb3cf7924b208ffa0a4c9e5d46c8)
useDailiyCorona.tsx 파일의 useEffect 훅의 언마운트된 상태를 체크하여 언마운트된 컴포넌트에서 상태 업데이트를 할 수 있도록 합니다. 

## 작업전 | 작업후
| Before | After |
|:-:|:-:|
|![1](https://user-images.githubusercontent.com/15684441/144981632-0009acaa-7824-4b88-ac29-31c600c14ad0.png)|![2](https://user-images.githubusercontent.com/15684441/144981679-0badd616-f085-4a5c-9d87-e9908205d86e.png)|

