### PR TITLE
코로나 전체 현황 컴포넌트를 생성합니다

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import Live from 'components/Live';
 import Modal from 'components/Modal';
 import RealTimeConfirmedCase from 'components/RealTimeConfirmedCase';
+import Stat from 'components/Stat';
 import modalHeader from 'interfaces/modalHeader.interface';
 import modalItems from 'interfaces/modalItems.interface';
 import React, {ReactElement, useState} from 'react';
@@ -24,6 +25,7 @@ export default function App(): ReactElement {
 
   return (
     <>
+      <Stat />
       <Live />
       <Modal open={modalOpen} close={closeModal} header={header} items={modalItem} />
       <RealTimeConfirmedCase openModal={openModal} setHeader={setHeader} setModalItems={setModalItems} />

--- a/src/components/Stat.test.tsx
+++ b/src/components/Stat.test.tsx
@@ -1,0 +1,22 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+import Stat from './Stat';
+
+test('전체 코로나 현황을 보여줍니다', async () => {
+  render(<Stat />);
+  const confirmedDisplayed = await waitFor(() => screen.getByRole('confirmed'));
+  expect(confirmedDisplayed.classList.contains('red')).toBe(true);
+  expect(confirmedDisplayed).toHaveTextContent('17,795,357');
+
+  const deceasedDisplayed = await waitFor(() => screen.getByRole('deceased'));
+  expect(deceasedDisplayed.classList.contains('gray')).toBe(true);
+  expect(deceasedDisplayed).toHaveTextContent('23,745');
+
+  const hospitalisedDisplayed = await waitFor(() => screen.getByRole('hospitalised'));
+  expect(hospitalisedDisplayed.classList.contains('blue')).toBe(true);
+  expect(hospitalisedDisplayed).toHaveTextContent('157');
+
+  const confirmedCriticalDisplayed = await waitFor(() => screen.getByRole('confirmedCritical'));
+  expect(confirmedCriticalDisplayed.classList.contains('gray')).toBe(true);
+  expect(confirmedCriticalDisplayed).toHaveTextContent('345');
+});

--- a/src/components/Stat.tsx
+++ b/src/components/Stat.tsx
@@ -1,0 +1,116 @@
+import useConfirmedStat from 'hooks/useConfirmedStat';
+import React, {ReactElement} from 'react';
+import styled from 'styled-components';
+
+const fontColors = {
+  red: '#eb5374',
+  blue: '#5673eb',
+  gray: '#464d52',
+};
+const backgroundColors = {
+  red: '#FDEAEE',
+  blue: '#eff2ff',
+  gray: '#f0f0f0',
+};
+
+const Stats = styled.div`
+  color: #464d52;
+  display: flex;
+  justify-content: space-around;
+`;
+const StatsItem = styled.div`
+  text-align: center;
+  line-height: 1.5;
+`;
+const Title = styled.div`
+  font-size: 0.725rem;
+`;
+const Confirmed = styled.div`
+  font-size: 0.975rem;
+  font-weight: bold;
+  &.red {
+    color: ${fontColors.red};
+  }
+  &.blue {
+    color: ${fontColors.blue};
+  }
+  &.gray {
+    color: ${fontColors.gray};
+  }
+`;
+const Increase = styled.div`
+  font-size: 0.75rem;
+  font-weight: bold;
+  border-radius: 1rem;
+  padding: 0.25rem 0.6rem;
+  &.red {
+    color: ${fontColors.red};
+    background-color: ${backgroundColors.red};
+  }
+  &.blue {
+    color: ${fontColors.blue};
+    background-color: ${backgroundColors.blue};
+  }
+  &.gray {
+    color: ${fontColors.gray};
+    background-color: ${backgroundColors.gray};
+  }
+  span {
+    margin: 0 0.15rem;
+  }
+`;
+
+export default function Stat(): ReactElement {
+  const {confirmed, deceased, hospitalised, confirmedCritical} = {...useConfirmedStat()};
+
+  return (
+    <div>
+      {!confirmed || !deceased || !hospitalised || !confirmedCritical ? (
+        <div>확진된 사람이 없습니다.</div>
+      ) : (
+        <Stats>
+          <StatsItem>
+            <Title>확진자</Title>
+            <Confirmed role="confirmed" className={confirmed.class}>
+              {confirmed.case}
+            </Confirmed>
+            <Increase className={confirmed.class}>
+              <span>{confirmed.increaseCase}</span>
+              <strong>{confirmed.arrow}</strong>
+            </Increase>
+          </StatsItem>
+          <StatsItem>
+            <Title>사망자</Title>
+            <Confirmed role="deceased" className={deceased.class}>
+              {deceased.case}
+            </Confirmed>
+            <Increase className={deceased.class}>
+              <span>{deceased.increaseCase}</span>
+              <strong>{deceased.arrow}</strong>
+            </Increase>
+          </StatsItem>
+          <StatsItem>
+            <Title>입원환자</Title>
+            <Confirmed role="hospitalised" className={hospitalised.class}>
+              {hospitalised.case}
+            </Confirmed>
+            <Increase className={hospitalised.class}>
+              <span>{hospitalised.increaseCase}</span>
+              <strong>{hospitalised.arrow}</strong>
+            </Increase>
+          </StatsItem>
+          <StatsItem>
+            <Title>위중증자</Title>
+            <Confirmed role="confirmedCritical" className={confirmedCritical.class}>
+              {confirmedCritical.case}
+            </Confirmed>
+            <Increase className={confirmedCritical.class}>
+              <span>{confirmedCritical.increaseCase}</span>
+              <strong>{confirmedCritical.arrow}</strong>
+            </Increase>
+          </StatsItem>
+        </Stats>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useConfirmedStat.tsx
+++ b/src/hooks/useConfirmedStat.tsx
@@ -1,0 +1,53 @@
+import axios from 'axios';
+import {confirmedStatApi, confirmedStat} from 'interfaces/confirmedStat.interface';
+import {useEffect, useState} from 'react';
+
+function getClass(increaseCase: number): string {
+  const result = 'gray';
+  return increaseCase >= 1000 ? 'red' : increaseCase < 0 ? 'blue' : result;
+}
+
+function getArrow(increaseCase: number): string {
+  return increaseCase > 0 ? '▲' : '▼';
+}
+
+export default function useConfirmedStat(): confirmedStat | undefined {
+  const [stat, setStat] = useState<confirmedStat>();
+
+  async function getStat() {
+    await axios.get<confirmedStatApi>('/region/stat').then(response => {
+      const data = response.data;
+      setStat({
+        confirmed: {
+          case: data.confirmed[0].toLocaleString(),
+          increaseCase: data.confirmed[1].toLocaleString(),
+          class: getClass(data.confirmed[1]),
+          arrow: getArrow(data.confirmed[1]),
+        },
+        deceased: {
+          case: data.deceased[0].toLocaleString(),
+          increaseCase: data.deceased[1].toLocaleString(),
+          class: getClass(data.deceased[1]),
+          arrow: getArrow(data.deceased[1]),
+        },
+        confirmedCritical: {
+          case: data.confirmedCritical[0].toLocaleString(),
+          increaseCase: data.confirmedCritical[1].toLocaleString(),
+          class: getClass(data.confirmedCritical[1]),
+          arrow: getArrow(data.confirmedCritical[1]),
+        },
+        hospitalised: {
+          case: data.hospitalised[0].toLocaleString(),
+          increaseCase: data.hospitalised[1].toLocaleString(),
+          class: getClass(data.hospitalised[1]),
+          arrow: getArrow(data.hospitalised[1]),
+        },
+      });
+    });
+  }
+  useEffect(() => {
+    getStat();
+  }, []);
+
+  return stat;
+}

--- a/src/interfaces/confirmedStat.interface.ts
+++ b/src/interfaces/confirmedStat.interface.ts
@@ -1,0 +1,19 @@
+export interface confirmedStatApi {
+  confirmed: number[]; // 확진자
+  deceased: number[]; // 사망자
+  confirmedCritical: number[]; // 위중증자
+  hospitalised: number[]; // 입원환자
+}
+
+type stat = {
+  case: string,
+  increaseCase: string,
+  class: string,
+  arrow: string,
+};
+export interface confirmedStat {
+  confirmed: stat;
+  deceased: stat;
+  confirmedCritical: stat;
+  hospitalised: stat;
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -685,4 +685,16 @@ export const taskDailyConfirmedCase = rest.get('/region/daily', (req, res, ctx) 
   );
 });
 
-export const handlers = [taskHandler, taskRealTimeConfirmedCase, taskDailyConfirmedCase, taskLive];
+export const taskStat = rest.get('/region/stat', (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      confirmed: [17795357, 13296],
+      deceased: [23745, 35],
+      confirmedCritical: [345, 7],
+      hospitalised: [157, -116],
+    }),
+  );
+});
+
+export const handlers = [taskHandler, taskRealTimeConfirmedCase, taskDailyConfirmedCase, taskLive, taskStat];


### PR DESCRIPTION
## 배경
- 현재까지 발생한 코로나 확진자수, 사망자수, 입원환자수, 위중증자수를 알 수 있어야 합니다

## 작업 내용
- 화면 제일 상단에 현재까지 발생한 코로나 현황을 보여줍니다

## 테스트 방법
1. .env 파일에 REACT_APP_API_DOMAIN host값을 입력합니다.([notion 문서 참고](https://www.notion.so/monssosa/API-367005a9a62445b3b603d3f91a1b3e01))
2. npm start
3. localhost:3000 접속
4. 화면 제일 상단에 현재까지 발생한 코로나 확진자수, 사망자수, 입원환자수, 위중증자수가 나오는지 확인합니다

## 리뷰 노트
- .env 파일에 REACT_APP_API_DOMAIN 값을 입력해주세요
- 확진자수, 사망자수, 입원환자수, 위중증자수가 각 1000명이 넘는 경우 빨간색으로 표시, 1000명 미만의 경우 회색 표시, 0보다 작을 경우 파란색으로 표시됩니다

## 스크린샷
| Before | After |
|:-:|:-:|
| ![화면 캡처 2022-07-08 145946](https://user-images.githubusercontent.com/15684441/177926785-79cf504c-becd-4ec7-98fe-6442097f1ca1.png)| ![화면 캡처 2022-07-08 145729](https://user-images.githubusercontent.com/15684441/177926657-548403c5-0cf6-4df9-9bcb-31949d6a82bd.png)|
